### PR TITLE
Add layouts Snug and Snux (Sertain mods)

### DIFF
--- a/layouts/snug.toml
+++ b/layouts/snug.toml
@@ -1,0 +1,14 @@
+name = "Snug"
+author = "mainstream"
+link = ""
+year = 2021
+
+[formats.standard]
+matrix = [
+  ["x", "l", "d", "m", "b", "y", "w", "o", "u", "q"],
+  ["s", "r", "t", "n", "f", "p", "c", "e", "i", "a"],
+  ["z", "j", "k", "h", "v", "'", "g", "/", ",", "."],
+]
+
+map = {}
+home_row = 1

--- a/layouts/snux.toml
+++ b/layouts/snux.toml
@@ -1,0 +1,14 @@
+name = "Snux"
+author = "mainstream"
+link = ""
+year = 2022
+
+[formats.standard]
+matrix = [
+  ["x", "l", "d", "m", "b", "y", "f", "o", "u", "'"],
+  ["s", "r", "t", "c", "g", "p", "n", "e", "i", "a"],
+  ["z", "j", "k", "w", "v", "q", "h", "/", ",", "."],
+]
+
+map = {}
+home_row = 1


### PR DESCRIPTION
Both my own layouts, Snug is a mod of Sertain and Snux is a mod of Snug with crossed-over (x) index keys to make more things like the German `sch` into a roll instead of an alternation