### PR TITLE
Rename CTGAP to CTGAP 2.0

### DIFF
--- a/layouts/ctgap2.toml
+++ b/layouts/ctgap2.toml
@@ -1,4 +1,4 @@
-name = "CTGAP"
+name = "CTGAP 2.0"
 author = "Colby Chai"
 link = "github.com/CTGAP/ctgap-keyboard-layout"
 year = 2021


### PR DESCRIPTION
"CTGAP" was a misnomer and refers to the defunct Colemak-based layout.