### PR TITLE
add standard esperanto qwerty layout (ekverto)

### DIFF
--- a/layouts/ekverto.toml
+++ b/layouts/ekverto.toml
@@ -1,0 +1,12 @@
+name = "Ekverto"
+author = "Benno Schulenberg"
+link = ""
+year = 2007
+
+[formats.standard]
+matrix = [["ŝ", "ĝ", "e", "r", "t", "ŭ", "u", "i", "o", "p", "ĵ", "ĥ", "\\"],
+["a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'"],
+["z", "ĉ", "c", "v", "b", "n", "m", ",", ".", "/"]]
+
+map = {}
+home_row = 1


### PR DESCRIPTION
standard layout from xkeyboard-config in x11, used by both linux and android