### PR TITLE
move backslash, fix year for ekverto

### DIFF
--- a/layouts/ekverto.toml
+++ b/layouts/ekverto.toml
@@ -1,11 +1,11 @@
 name = "Ekverto"
 author = "Benno Schulenberg"
 link = ""
-year = 2007
+year = 2006
 
 [formats.standard]
-matrix = [["ŝ", "ĝ", "e", "r", "t", "ŭ", "u", "i", "o", "p", "ĵ", "ĥ", "\\"],
-["a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'"],
+matrix = [["ŝ", "ĝ", "e", "r", "t", "ŭ", "u", "i", "o", "p", "ĵ", "ĥ"],
+["a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'", "\\"],
 ["z", "ĉ", "c", "v", "b", "n", "m", ",", ".", "/"]]
 
 map = {}


### PR DESCRIPTION
While the layout was officially committed in 2007, it was originally conceived in, and officially dated as, December 2006.
Additionally, the backslash is moved to its ISO position for a cleaner matrix representation in text form.