### PR TITLE
Fix Radish

### DIFF
--- a/layouts/radish.toml
+++ b/layouts/radish.toml
@@ -1,7 +1,7 @@
-name = "Dvorak"
-author = "August Dvorak"
-link = ""
-year = 1936
+name = "Radish"
+author = "Qwertron"
+link = "https://discord.com/channels/807843650717483049/807844118826975262/980842532600705064"
+year = 2022
 
 [formats.standard]
 matrix = [["v", "c", "w", "f", "q", "z", "p", "u", "o", "y", "/", "="],


### PR DESCRIPTION
Radish was not made in 1936 by August Dvorak, and was also not called Dvorak